### PR TITLE
Actualizar script de linting en package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,7 @@ updates:
     ignore:
       - dependency-name: "eslint"
         versions: ["<8.0.0"]
-    allow:
-      - dependency-type: "all"
-    security-updates-only: true
-
+        
   #Update Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change removes the `allow` section and the `security-updates-only` setting for dependencies.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L12-L14): Removed the `allow` section and the `security-updates-only` setting for dependencies.